### PR TITLE
fix(commands.create_note): allow create/select subdirectory before creating a new note

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,10 +329,11 @@ dotmd/
 
 When you create a new note, **dotmd.nvim**:
 
-1. Prompts for a file name or path. (See [Input patterns](#input-patterns))
-2. Generates a file path inside the configured notes folder.
-3. Optionally applies a notes template.
-4. Opens the file in a vertical/horizontal split or current window.
+1. Prompts for select/create a subdirectory or use the base directory.
+2. Prompts for a file name or path. (See [Input patterns](#input-patterns))
+3. Generates a file path inside the configured notes folder.
+4. Optionally applies a notes template.
+5. Opens the file in a vertical/horizontal split or current window.
 
 #### Input patterns
 

--- a/doc/dotmd.nvim.txt
+++ b/doc/dotmd.nvim.txt
@@ -332,10 +332,11 @@ FILE CREATION ~
 
 When you create a new note, **dotmd.nvim**
 
-1. Promptsfor a file name or path. (See |dotmd.nvim-input-patterns|)
-2. Generates a file path inside the configured notes folder.
-3. Optionally applies a notes template.
-4. Opens the file in a vertical/horizontal split or current window.
+1. Promptsfor select/create a subdirectory or use the base directory.
+2. Prompts for a file name or path. (See |dotmd.nvim-input-patterns|)
+3. Generates a file path inside the configured notes folder.
+4. Optionally applies a notes template.
+5. Opens the file in a vertical/horizontal split or current window.
 
 
 INPUT PATTERNS

--- a/lua/dotmd/directories.lua
+++ b/lua/dotmd/directories.lua
@@ -46,4 +46,36 @@ function M.get_picker_dirs(opts)
 	return dirs
 end
 
+--- Get subdirectories from a base path
+---@param base_path string The base path to get subdirectories from
+---@return string[] subdirs The subdirectories
+function M.get_subdirs_recursive(base_path)
+	local subdirs = {}
+
+	local function scan_dir(current_path, prefix)
+		prefix = prefix or ""
+		local scandir = vim.uv.fs_scandir(current_path)
+		if scandir then
+			while true do
+				local name, type = vim.uv.fs_scandir_next(scandir)
+				if not name then
+					break
+				end
+				if type == "directory" then
+					local relative_dir = prefix .. name
+					table.insert(subdirs, relative_dir)
+					scan_dir(current_path .. "/" .. name, relative_dir .. "/")
+				end
+			end
+		end
+	end
+
+	scan_dir(base_path, "")
+
+	table.insert(subdirs, 1, "[Create new subdirectory]")
+	table.insert(subdirs, 2, "[base directory]")
+
+	return subdirs
+end
+
 return M

--- a/lua/dotmd/prompt.lua
+++ b/lua/dotmd/prompt.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+--- Input a note name/path
+---@param opts DotMd.CreateFileOpts Options for creating the file
+---@return nil
+function M.input_note_name(base_path, opts)
+	vim.ui.input({
+		prompt = "Note name/path: ",
+		default = "",
+	}, function(name_or_path)
+		local utils = require("dotmd.utils")
+		local config = require("dotmd.config").config
+
+		if not name_or_path or name_or_path == "" then
+			return
+		end
+
+		local subdir = vim.fn.fnamemodify(name_or_path, ":h")
+		local filename = vim.fn.fnamemodify(name_or_path, ":t")
+
+		if subdir ~= "." then
+			base_path = base_path .. subdir .. "/"
+			utils.ensure_directory(base_path)
+		end
+
+		local formatted_name = utils.format_filename(filename)
+		local note_path = utils.get_unique_filepath(base_path, formatted_name)
+
+		local display_name = utils.is_path_like(name_or_path)
+				and utils.deformat_filename(filename)
+			or name_or_path
+
+		utils.write_file(note_path, display_name, config.templates.notes)
+
+		if opts.open then
+			utils.open_file(note_path, opts)
+		end
+	end)
+end
+
+return M

--- a/tests/directories_spec.lua
+++ b/tests/directories_spec.lua
@@ -107,4 +107,51 @@ describe("dotmd.directories module", function()
 			end
 		)
 	end)
+
+	describe("get_subdirs_recursive", function()
+		local tmp_dir = nil
+
+		-- Create a temporary directory structure for testing.
+		before_each(function()
+			-- Create a unique temporary directory.
+			tmp_dir = vim.fn.tempname()
+			vim.fn.mkdir(tmp_dir, "p")
+
+			-- Create subdirectories:
+			-- tmp_dir/sub1
+			-- tmp_dir/sub1/nested
+			-- tmp_dir/sub2
+			vim.fn.mkdir(tmp_dir .. "/sub1", "p")
+			vim.fn.mkdir(tmp_dir .. "/sub1/nested", "p")
+			vim.fn.mkdir(tmp_dir .. "/sub2", "p")
+		end)
+
+		-- Clean up the temporary directory after each test.
+		after_each(function()
+			-- Recursively remove the temporary directory.
+			os.execute("rm -rf " .. tmp_dir)
+		end)
+
+		it(
+			"returns subdirectories recursively with expected headers",
+			function()
+				local subdirs = directories.get_subdirs_recursive(tmp_dir)
+
+				-- Verify that the two header strings are the first two items.
+				assert.equals("[Create new subdirectory]", subdirs[1])
+				assert.equals("[base directory]", subdirs[2])
+
+				-- Since the order of subdirectories from the filesystem might not be guaranteed,
+				-- check that the expected paths are present in the returned list.
+				local found = {}
+				for i = 3, #subdirs do
+					found[subdirs[i]] = true
+				end
+
+				assert.is_true(found["sub1"])
+				assert.is_true(found["sub1/nested"])
+				assert.is_true(found["sub2"])
+			end
+		)
+	end)
 end)


### PR DESCRIPTION
This change will add a select prompt before note creation to select a
subdirectory or create a new subdirectory for the note creation.
Previously we can already just type `folder/something` and it will
create the folder. Now the behaviour are still the same, but we added a
new select picker for easier selection of subdirectory as we go.

Note that if a subdirectory is selected and the input also has
subdirectory in it, it will get nested. For example:

- Selected: `linux-note`
- Input: `linux-note/linux-is-amazing.md`
- Result: `linux-note/linux-note/linux-is-amazing.md`

It's recommended to just type in the name or filename instead of nested
path with filename
