### PR TITLE
fix(utils.merge_default_create_file_opts): remove hardcoded `vertical` for `opts.split`

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Prompt to create and open a new markdown note.
 ```lua
 ---@class DotMd.CreateFileOpts
 ---@field open? boolean Open the file after creation, default is true
----@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@param opts? DotMd.CreateFileOpts
 require("dotmd").create_note(opts)
@@ -443,7 +443,7 @@ Open/create today’s todo and roll over tasks.
 ```lua
 ---@class DotMd.CreateFileOpts
 ---@field open? boolean Open the file after creation, default is true
----@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@param opts? DotMd.CreateFileOpts
 require("dotmd").create_todo_today(opts)
@@ -461,7 +461,7 @@ Open/create a journal entry for today.
 ```lua
 ---@class DotMd.CreateFileOpts
 ---@field open? boolean Open the file after creation, default is true
----@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@param opts? DotMd.CreateFileOpts
 require("dotmd").create_journal(opts)
@@ -479,7 +479,7 @@ Open the central `inbox.md`.
 ```lua
 ---@class DotMd.CreateFileOpts
 ---@field open? boolean Open the file after creation, default is true
----@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@param opts? DotMd.CreateFileOpts
 require("dotmd").create_journal(opts)

--- a/doc/dotmd.nvim.txt
+++ b/doc/dotmd.nvim.txt
@@ -438,7 +438,7 @@ Prompt to create and open a new markdown note.
 >lua
     ---@class DotMd.CreateFileOpts
     ---@field open? boolean Open the file after creation, default is true
-    ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+    ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
     
     ---@param opts? DotMd.CreateFileOpts
     require("dotmd").create_note(opts)
@@ -458,7 +458,7 @@ Open/create today’s todo and roll over tasks.
 >lua
     ---@class DotMd.CreateFileOpts
     ---@field open? boolean Open the file after creation, default is true
-    ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+    ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
     
     ---@param opts? DotMd.CreateFileOpts
     require("dotmd").create_todo_today(opts)
@@ -478,7 +478,7 @@ Open/create a journal entry for today.
 >lua
     ---@class DotMd.CreateFileOpts
     ---@field open? boolean Open the file after creation, default is true
-    ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+    ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
     
     ---@param opts? DotMd.CreateFileOpts
     require("dotmd").create_journal(opts)
@@ -498,7 +498,7 @@ Open the central `inbox.md`.
 >lua
     ---@class DotMd.CreateFileOpts
     ---@field open? boolean Open the file after creation, default is true
-    ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+    ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
     
     ---@param opts? DotMd.CreateFileOpts
     require("dotmd").create_journal(opts)

--- a/lua/dotmd/types.lua
+++ b/lua/dotmd/types.lua
@@ -19,7 +19,7 @@
 
 ---@class DotMd.CreateFileOpts
 ---@field open? boolean Open the file after creation, default is true
----@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `vertical`
+---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@class DotMd.PickOpts
 ---@field type? "notes" | "todos" | "journal" | "all" Pick type, default is `notes`

--- a/lua/dotmd/utils.lua
+++ b/lua/dotmd/utils.lua
@@ -6,9 +6,7 @@ local M = {}
 function M.merge_default_create_file_opts(opts)
 	opts = opts or {}
 	opts.open = opts.open ~= false
-	opts.split = opts.split
-		or require("dotmd.config").config.default_split
-		or "vertical"
+	opts.split = opts.split or require("dotmd.config").config.default_split
 	return opts
 end
 

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -12,7 +12,6 @@ describe("dotmd.utils module", function()
 			assert.is_true(opts.open)
 			-- opts.split should be set to either dotmd.config default_split or "vertical"
 			local expected = require("dotmd.config").config.default_split
-				or "vertical"
 			assert.are.equal(expected, opts.split)
 		end)
 


### PR DESCRIPTION
It should just fallback to the `config.default_split`
