### PR TITLE
fix(commands): remove `open_file` opts and always open the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,6 @@ Prompt to create and open a new markdown note.
 
 ```lua
 ---@class DotMd.CreateFileOpts
----@field open? boolean Open the file after creation, default is true
 ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@param opts? DotMd.CreateFileOpts
@@ -433,7 +432,7 @@ require("dotmd").create_note(opts)
 
 You can also use the command `:DotMdCreateNote` to create a new note. And it supports the same options.
 
-### Create Todo for Today Date
+### Create or open Todo for Today Date
 
 Open/create today’s todo and roll over tasks.
 
@@ -442,7 +441,6 @@ Open/create today’s todo and roll over tasks.
 
 ```lua
 ---@class DotMd.CreateFileOpts
----@field open? boolean Open the file after creation, default is true
 ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@param opts? DotMd.CreateFileOpts
@@ -451,7 +449,7 @@ require("dotmd").create_todo_today(opts)
 
 You can also use the command `:DotMdCreateTodoToday` to create a new todo for today. And it supports the same options.
 
-### Create Journal for Today Date
+### Create or open Journal for Today Date
 
 Open/create a journal entry for today.
 
@@ -460,7 +458,6 @@ Open/create a journal entry for today.
 
 ```lua
 ---@class DotMd.CreateFileOpts
----@field open? boolean Open the file after creation, default is true
 ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@param opts? DotMd.CreateFileOpts
@@ -478,7 +475,6 @@ Open the central `inbox.md`.
 
 ```lua
 ---@class DotMd.CreateFileOpts
----@field open? boolean Open the file after creation, default is true
 ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@param opts? DotMd.CreateFileOpts

--- a/doc/dotmd.nvim.txt
+++ b/doc/dotmd.nvim.txt
@@ -437,7 +437,6 @@ Prompt to create and open a new markdown note.
   prefix if the file exists. To open a note, use the `pick` command instead.
 >lua
     ---@class DotMd.CreateFileOpts
-    ---@field open? boolean Open the file after creation, default is true
     ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
     
     ---@param opts? DotMd.CreateFileOpts
@@ -448,7 +447,7 @@ You can also use the command `:DotMdCreateNote` to create a new note. And it
 supports the same options.
 
 
-CREATE TODO FOR TODAY DATE ~
+CREATE OR OPEN TODO FOR TODAY DATE ~
 
 Open/create today’s todo and roll over tasks.
 
@@ -457,7 +456,6 @@ Open/create today’s todo and roll over tasks.
   creates a new one.
 >lua
     ---@class DotMd.CreateFileOpts
-    ---@field open? boolean Open the file after creation, default is true
     ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
     
     ---@param opts? DotMd.CreateFileOpts
@@ -468,7 +466,7 @@ You can also use the command `:DotMdCreateTodoToday` to create a new todo for
 today. And it supports the same options.
 
 
-CREATE JOURNAL FOR TODAY DATE ~
+CREATE OR OPEN JOURNAL FOR TODAY DATE ~
 
 Open/create a journal entry for today.
 
@@ -477,7 +475,6 @@ Open/create a journal entry for today.
   creates a new one.
 >lua
     ---@class DotMd.CreateFileOpts
-    ---@field open? boolean Open the file after creation, default is true
     ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
     
     ---@param opts? DotMd.CreateFileOpts
@@ -497,7 +494,6 @@ Open the central `inbox.md`.
   just be there for you to dump thoughts, tasks, and references.
 >lua
     ---@class DotMd.CreateFileOpts
-    ---@field open? boolean Open the file after creation, default is true
     ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
     
     ---@param opts? DotMd.CreateFileOpts

--- a/lua/dotmd/commands.lua
+++ b/lua/dotmd/commands.lua
@@ -102,14 +102,10 @@ function M.create_todo_today(opts)
 				)
 			end
 
-			if opts.open then
-				utils.open_file(todo_path, opts)
-			end
+			utils.open_file(todo_path, opts)
 		end)
 	else
-		if opts.open then
-			utils.open_file(todo_path, opts)
-		end
+		utils.open_file(todo_path, opts)
 	end
 end
 
@@ -151,14 +147,10 @@ function M.create_journal(opts)
 				config.templates.journal
 			)
 
-			if opts.open then
-				utils.open_file(journal_path, opts)
-			end
+			utils.open_file(journal_path, opts)
 		end)
 	else
-		if opts.open then
-			utils.open_file(journal_path, opts)
-		end
+		utils.open_file(journal_path, opts)
 	end
 end
 
@@ -178,9 +170,7 @@ function M.inbox(opts)
 		utils.write_file(inbox_path, "Inbox", config.templates.inbox)
 	end
 
-	if opts.open then
-		utils.open_file(inbox_path, opts)
-	end
+	utils.open_file(inbox_path, opts)
 end
 
 --- Pick a file from a list of directories

--- a/lua/dotmd/prompt.lua
+++ b/lua/dotmd/prompt.lua
@@ -32,9 +32,7 @@ function M.input_note_name(base_path, opts)
 
 		utils.write_file(note_path, display_name, config.templates.notes)
 
-		if opts.open then
-			utils.open_file(note_path, opts)
-		end
+		utils.open_file(note_path, opts)
 	end)
 end
 

--- a/lua/dotmd/types.lua
+++ b/lua/dotmd/types.lua
@@ -18,7 +18,6 @@
 ---@field inbox? fun(date: string): string[]
 
 ---@class DotMd.CreateFileOpts
----@field open? boolean Open the file after creation, default is true
 ---@field split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is based on `default_split` in config
 
 ---@class DotMd.PickOpts

--- a/lua/dotmd/utils.lua
+++ b/lua/dotmd/utils.lua
@@ -5,7 +5,6 @@ local M = {}
 ---@return DotMd.CreateFileOpts
 function M.merge_default_create_file_opts(opts)
 	opts = opts or {}
-	opts.open = opts.open ~= false
 	opts.split = opts.split or require("dotmd.config").config.default_split
 	return opts
 end

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -8,16 +8,9 @@ describe("dotmd.utils module", function()
 	describe("merge_default_create_file_opts", function()
 		it("should set default values when no opts provided", function()
 			local opts = utils.merge_default_create_file_opts()
-			-- by default opts.open is true if not explicitly false
-			assert.is_true(opts.open)
 			-- opts.split should be set to either dotmd.config default_split or "vertical"
 			local expected = require("dotmd.config").config.default_split
 			assert.are.equal(expected, opts.split)
-		end)
-
-		it("should keep opts.open false if provided as false", function()
-			local opts = utils.merge_default_create_file_opts({ open = false })
-			assert.is_false(opts.open)
 		end)
 	end)
 


### PR DESCRIPTION
With more thinking, I think this is not necessary and we can just always
open the file.
