### PR TITLE
fix(config): add configurable `rollover_todo` for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ require("dotmd").setup({
 ---@class DotMd.Config
 ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
 ---@field default_split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `none`
+---@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
 ---@field dir_names? DotMd.Config.DirNames
 ---@field templates? Dotmd.Config.Templates
 
@@ -102,6 +103,7 @@ require("dotmd").setup({
 {
  root_dir = "~/dotmd",
  default_split = "none",
+ rollover_todo = true,
  dir_names = {
   notes = "notes",
   todo = "todo",
@@ -368,7 +370,7 @@ When you create a new todo file, **dotmd.nvim**:
 
 1. Checks if today's todo file exists (e.g. `todo/2025-04-09.md`).
 2. If the file doesn't exist, prompt for create confirmation.
-3. If confirm, rolls over unfinished `- [ ] tasks from the previous file` from the nearest previous todo file (if any).
+3. If confirm, rolls over unfinished `- [ ] tasks from the previous file` from the nearest previous todo file (if any and enabled).
 4. Applies the todo template.
 5. Opens the file for editing.
 

--- a/doc/dotmd.nvim.txt
+++ b/doc/dotmd.nvim.txt
@@ -83,6 +83,7 @@ DEFAULT OPTIONS ~
     ---@class DotMd.Config
     ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
     ---@field default_split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `none`
+    ---@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
     ---@field dir_names? DotMd.Config.DirNames
     ---@field templates? Dotmd.Config.Templates
     
@@ -99,6 +100,7 @@ DEFAULT OPTIONS ~
     {
      root_dir = "~/dotmd",
      default_split = "none",
+     rollover_todo = true,
      dir_names = {
       notes = "notes",
       todo = "todo",
@@ -373,7 +375,7 @@ When you create a new todo file, **dotmd.nvim**
 
 1. Checksif today’s todo file exists (e.g. `todo/2025-04-09.md`).
 2. If the file doesn’t exist, prompt for create confirmation.
-3. If confirm, rolls over unfinished `- [ ] tasks from the previous file` from the nearest previous todo file (if any).
+3. If confirm, rolls over unfinished `- [ ] tasks from the previous file` from the nearest previous todo file (if any and enabled).
 4. Applies the todo template.
 5. Opens the file for editing.
 

--- a/lua/dotmd/commands.lua
+++ b/lua/dotmd/commands.lua
@@ -84,22 +84,24 @@ function M.create_todo_today(opts)
 				config.templates.todo
 			)
 
-			local unchecked_tasks, source_path =
-				todos.rollover_previous_todo_to_today(todo_dir, today)
-			if unchecked_tasks and source_path then
-				local today_lines = vim.fn.readfile(todo_path)
-				if #today_lines > 0 and today_lines[#today_lines] ~= "" then
-					table.insert(today_lines, "")
-				end
-				vim.list_extend(today_lines, unchecked_tasks)
-				utils.safe_writefile(today_lines, todo_path)
-				vim.notify(
-					string.format(
-						"Rolled over %d unchecked todo(s) from %s",
-						#unchecked_tasks,
-						vim.fn.fnamemodify(source_path, ":t")
+			if config.rollover_todo == true then
+				local unchecked_tasks, source_path =
+					todos.rollover_previous_todo_to_today(todo_dir, today)
+				if unchecked_tasks and source_path then
+					local today_lines = vim.fn.readfile(todo_path)
+					if #today_lines > 0 and today_lines[#today_lines] ~= "" then
+						table.insert(today_lines, "")
+					end
+					vim.list_extend(today_lines, unchecked_tasks)
+					utils.safe_writefile(today_lines, todo_path)
+					vim.notify(
+						string.format(
+							"Rolled over %d unchecked todo(s) from %s",
+							#unchecked_tasks,
+							vim.fn.fnamemodify(source_path, ":t")
+						)
 					)
-				)
+				end
 			end
 
 			utils.open_file(todo_path, opts)

--- a/lua/dotmd/config.lua
+++ b/lua/dotmd/config.lua
@@ -6,6 +6,7 @@ M.config = {}
 local defaults = {
 	root_dir = "~/dotmd",
 	default_split = "none",
+	rollover_todo = true,
 	dir_names = {
 		notes = "notes",
 		todo = "todo",

--- a/lua/dotmd/types.lua
+++ b/lua/dotmd/types.lua
@@ -1,6 +1,7 @@
 ---@class DotMd.Config
 ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
 ---@field default_split? "vertical" | "horizontal" | "none" Split direction for new or existing files, default is `none`
+---@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
 ---@field dir_names? DotMd.Config.DirNames
 ---@field templates? Dotmd.Config.Templates
 


### PR DESCRIPTION
This change allows user to decide whether they want their todos to be
rollover from the nearest previous todo (if any)
