### PR TITLE
feat(commands.open): add ability to `pluralised` the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ See the example below for how to configure **dotmd.nvim**.
   {
    "<leader>no",
    function()
-    require("dotmd").open()
+    require("dotmd").open({
+     pluralise_query = true, -- recommended
+    })
    end,
    mode = "n",
    desc = "[DotMd] Open",
@@ -551,7 +553,9 @@ You can also use the command `:DotMdNavigate` to navigate to the nearest previou
 Open a files intelligently in **dotmd.nvim** directories by `type`. You can either provide a `query` or it will prompt for the search query.
 
 > [!note]
-> The query is a string and it will be fuzzy-matched.
+> The query are matched by splitted tokens in a case-insensitive way.
+> If you want to have the behavior to get matches by plurals, you can set `pluralise_query` to `true`.
+> For example, if you search for `todo` it will match `todos` and `todo`.
 
 ```lua
 ---@alias DotMd.PickType "notes" | "todos" | "journal" | "all" Pick type
@@ -560,6 +564,7 @@ Open a files intelligently in **dotmd.nvim** directories by `type`. You can eith
 ---@field type? DotMd.PickType Open type, default is `all`
 ---@field query? string Query to filter the files
 ---@field split? DotMd.Split Split direction for new or existing files, default is based on `default_split` in config
+---@field pluralise_query? boolean Pluralise the query, default is `false`
 
 ---@param opts? DotMd.OpenOpts Options for opening the file
 require("dotmd").open(opts)
@@ -585,7 +590,7 @@ bind-key -T dotmd t run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Todo' 'sh -
 bind-key -T dotmd n run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Note' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdCreateNote split=none\\\"\"'"
 bind-key -T dotmd i run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Inbox' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdInbox split=none\\\"\"'"
 bind-key -T dotmd j run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Journal' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdCreateJournal split=none\\\"\"'"
-bind-key -T dotmd o run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Open' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdOpen split=none\\\"\"'"
+bind-key -T dotmd o run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Open' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdOpen split=none pluralise_query=true\\\"\"'"
 bind-key -T dotmd r run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Root' 'sh -c \"cd ~/dotmd && nvim\"'"
 
 # switch back to root keytable with escape

--- a/doc/dotmd.nvim.txt
+++ b/doc/dotmd.nvim.txt
@@ -247,7 +247,9 @@ See the example below for how to configure **dotmd.nvim**.
       {
        "<leader>no",
        function()
-        require("dotmd").open()
+        require("dotmd").open({
+         pluralise_query = true, -- recommended
+        })
        end,
        mode = "n",
        desc = "[DotMd] Open",
@@ -578,7 +580,10 @@ Open a files intelligently in **dotmd.nvim** directories by `type`. You can
 either provide a `query` or it will prompt for the search query.
 
 
-  [!note] The query is a string and it will be fuzzy-matched.
+  [!note] The query are matched by splitted tokens in a case-insensitive way. If
+  you want to have the behavior to get matches by plurals, you can set
+  `pluralise_query` to `true`. For example, if you search for `todo` it will
+  match `todos` and `todo`.
 >lua
     ---@alias DotMd.PickType "notes" | "todos" | "journal" | "all" Pick type
     
@@ -586,6 +591,7 @@ either provide a `query` or it will prompt for the search query.
     ---@field type? DotMd.PickType Open type, default is `all`
     ---@field query? string Query to filter the files
     ---@field split? DotMd.Split Split direction for new or existing files, default is based on `default_split` in config
+    ---@field pluralise_query? boolean Pluralise the query, default is `false`
     
     ---@param opts? DotMd.OpenOpts Options for opening the file
     require("dotmd").open(opts)
@@ -614,7 +620,7 @@ adding the following to your `~/.tmux.conf`
     bind-key -T dotmd n run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Note' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdCreateNote split=none\\\"\"'"
     bind-key -T dotmd i run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Inbox' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdInbox split=none\\\"\"'"
     bind-key -T dotmd j run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Journal' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdCreateJournal split=none\\\"\"'"
-    bind-key -T dotmd o run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Open' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdOpen split=none\\\"\"'"
+    bind-key -T dotmd o run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Open' 'sh -c \"cd ~/dotmd && nvim +\\\"DotMdOpen split=none pluralise_query=true\\\"\"'"
     bind-key -T dotmd r run-shell "tmux popup -E -w 90% -h 80% -T 'Dotmd Root' 'sh -c \"cd ~/dotmd && nvim\"'"
     
     # switch back to root keytable with escape

--- a/lua/dotmd/commands.lua
+++ b/lua/dotmd/commands.lua
@@ -304,6 +304,8 @@ function M.open(opts)
 
 	opts = opts or {}
 	opts.type = opts.type or "all"
+	opts.split = opts.split or require("dotmd.config").config.default_split
+	opts.pluralise_query = opts.pluralise_query or false
 
 	local dirs = directories.get_picker_dirs(opts.type)
 
@@ -330,7 +332,6 @@ function M.open(opts)
 		end
 
 		local function normalize(s)
-			-- Lowercase and replace non-word characters with spaces
 			return s:lower():gsub("[%-_%.]", " ")
 		end
 
@@ -338,9 +339,10 @@ function M.open(opts)
 			local normalized_display = normalize(item.display)
 
 			for _, word in ipairs(query_words) do
-				if
-					not normalized_display:find("%f[%w]" .. word .. "%f[%W]")
-				then
+				-- Also support optional "s" at the end of the word for plurals if configured
+				local plural_suffix = opts.pluralise_query and "s?" or ""
+				local pattern = "%f[%w]" .. word .. plural_suffix .. "%f[%W]"
+				if not normalized_display:find(pattern) then
 					return false
 				end
 			end

--- a/lua/dotmd/types.lua
+++ b/lua/dotmd/types.lua
@@ -31,3 +31,4 @@
 ---@field type? DotMd.PickType Open type, default is `all`
 ---@field query? string Query to filter the files
 ---@field split? DotMd.Split Split direction for new or existing files, default is based on `default_split` in config
+---@field pluralise_query? boolean Pluralise the query, default is `false`


### PR DESCRIPTION
This changes will allow the behaviour of pluralising the query for
opening a file. For example: searching for `campaign` will try to match
`campaign` and also `campaigns`.

In my opinion, this changes is good for the `open` command, as
sometimes, we don't actually remember everything, especially whether it
is pluralised or not.
