### PR TITLE
feat(commands.picker): add `snacks`, `telescope` and `fzf-lua` picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ So I started building dotmd — something small and focused. I wanted a way to w
 - 📄 **Smart File Creation:** Easily create files with optional templates and unique file naming.
 - 📝 **Daily Todos:** Auto-generate daily todo files and rollover unchecked tasks from the nearest previous day.
 - 📅 **Daily Journals:** Quickly generate a markdown journal entry for the current date.
-- 🔍 **Note Picker:** Search or grep your notes across all categories using `vim.ui.select` or the `snacks.nvim` plugin if available.
+- 🔍 **Note Picker:** Search or grep your notes across all categories using `vim.ui.select` or the `snacks.nvim` or `fzf-lua` or `telescope.nvim` picker.
 - 📌 **Inbox:** Quick dump zone for thoughts, tasks, and references.
 - 🧭 **Smart Navigation:** Move to the nearest previous/next `todo` or `journal` entry automagically.
 - 🔧 **Fully Configurable:** Customize directories, templates, and behavior.
@@ -70,8 +70,11 @@ require("dotmd").setup({
 - Neovim 0.9+ with Lua support
 - The following CLI tools must be available in your $PATH:
   - `find`: for listing files across note directories
+  - `grep`: for searching files across note directories
 - Optional but recommended:
   - [snacks.nvim](https://github.com/folke/snacks.nvim): For better note picking and grepping
+  - [fzf-lua](https://github.com/ibhagwan/fzf-lua): For better note picking and grepping
+  - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim): For better note picking and grepping
 
 ## ⚙️ Configuration
 
@@ -84,10 +87,12 @@ require("dotmd").setup({
 
 ```lua
 ---@alias DotMd.Split "vertical" | "horizontal" | "none" Split direction
+---@alias DotMd.PickerType "telescope" | "fzf" | "snacks" Picker type
 
 ---@class DotMd.Config
 ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
 ---@field default_split? DotMd.Split Split direction for new or existing files, default is `none`
+---@field picker? DotMd.PickerType Picker type, default is `nil`
 ---@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
 ---@field dir_names? DotMd.Config.DirNames
 ---@field templates? Dotmd.Config.Templates
@@ -106,6 +111,7 @@ require("dotmd").setup({
  root_dir = "~/dotmd",
  default_split = "none",
  rollover_todo = true,
+ picker = nil,
  dir_names = {
   notes = "notes",
   todo = "todo",
@@ -189,8 +195,11 @@ See the example below for how to configure **dotmd.nvim**.
   "DotMdPick",
   "DotMdOpen",
  },
+ event = "VeryLazy",
  ---@type DotMd.Config
- opts = {},
+ opts = {
+  picker = "snacks" -- or "fzf" or "telescope" based on your preference
+ },
  keys = {
   {
    "<leader>nc",
@@ -402,8 +411,8 @@ When you create a new journal file, **dotmd.nvim**:
 
 ### Picker
 
-1. Uses `vim.ui.select` for file list or grep.
-2. If `snacks.nvim` is installed, uses `snacks.picker.grep()` or `snacks.picker.files()` for enhanced UX.
+1. Uses `vim.ui.select` for file list or grep as fallback or default.
+2. You can choose to use `snacks.nvim`, `fzf-lua`, or `telescope.nvim` for the picker based on your preference.
 3. Can filter by file type (notes, todo, journal, or all).
 
 ### Open
@@ -517,15 +526,17 @@ You can also use the command `:DotMdInbox` to open the central `inbox.md`. And i
 Pick or search files in **dotmd.nvim** directories by `type`.
 
 > [!note]
-> Recommended to use `snacks.nvim` for enhanced UX, else will fallback to `vim.ui.select`.
+> Recommended to any of the pickers `snacks.nvim`, `fzf-lua`, or `telescope.nvim` for enhanced UX, else will fallback to `vim.ui.select`.
 
 > [!warning]
 > `grep` option is not supported and will do nothing for the fallback.
 
 ```lua
 ---@alias DotMd.PickType "notes" | "todos" | "journal" | "all" Pick type
+---@alias DotMd.PickerType "telescope" | "fzf" | "snacks" Picker type
 
 ---@class DotMd.PickOpts
+---@field picker? DotMd.PickerType Picker type, default is based on `picker` in config
 ---@field type? DotMd.PickType Pick type, default is `notes`
 ---@field grep? boolean Grep the selected type directory for a string, default is false
 
@@ -534,8 +545,6 @@ require("dotmd").pick(opts)
 ```
 
 You can also use the command `:DotMdPick` to pick or search files in **dotmd.nvim** directories by `type`. And it supports the same options.
-
-Since I am exclusively using `snacks.nvim`, if you need some other picker to be integrated, feel free to help out and send in a PR for it.
 
 ### Navigate to Previous/Next Nearest `journal` or `todo` File
 

--- a/doc/dotmd.nvim.txt
+++ b/doc/dotmd.nvim.txt
@@ -27,7 +27,7 @@ FEATURES                                      *dotmd.nvim-dotmd.nvim-features*
 - **Smart File Creation:** Easily create files with optional templates and unique file naming.
 - **Daily Todos:** Auto-generate daily todo files and rollover unchecked tasks from the nearest previous day.
 - **Daily Journals:** Quickly generate a markdown journal entry for the current date.
-- **Note Picker:** Search or grep your notes across all categories using `vim.ui.select` or the `snacks.nvim` plugin if available.
+- **Note Picker:** Search or grep your notes across all categories using `vim.ui.select` or the `snacks.nvim` or `fzf-lua` or `telescope.nvim` picker.
 - **Inbox:** Quick dump zone for thoughts, tasks, and references.
 - **Smart Navigation:** Move to the nearest previous/next `todo` or `journal` entry automagically.
 - **Fully Configurable:** Customize directories, templates, and behavior.
@@ -64,8 +64,11 @@ REQUIREMENTS ~
 - Neovim0.9+ with Lua support
 - The following CLI tools must be available in your $PATH:
     - `find`for listing files across note directories
+    - `grep`for searching files across note directories
 - Optional but recommended:
     - snacks.nvim <https://github.com/folke/snacks.nvim>For better note picking and grepping
+    - fzf-lua <https://github.com/ibhagwan/fzf-lua>For better note picking and grepping
+    - telescope.nvim <https://github.com/nvim-telescope/telescope.nvim>For better note picking and grepping
 
 
 CONFIGURATION                            *dotmd.nvim-dotmd.nvim-configuration*
@@ -81,10 +84,12 @@ DEFAULT OPTIONS ~
 
 >lua
     ---@alias DotMd.Split "vertical" | "horizontal" | "none" Split direction
+    ---@alias DotMd.PickerType "telescope" | "fzf" | "snacks" Picker type
     
     ---@class DotMd.Config
     ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
     ---@field default_split? DotMd.Split Split direction for new or existing files, default is `none`
+    ---@field picker? DotMd.PickerType Picker type, default is `nil`
     ---@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
     ---@field dir_names? DotMd.Config.DirNames
     ---@field templates? Dotmd.Config.Templates
@@ -103,6 +108,7 @@ DEFAULT OPTIONS ~
      root_dir = "~/dotmd",
      default_split = "none",
      rollover_todo = true,
+     picker = nil,
      dir_names = {
       notes = "notes",
       todo = "todo",
@@ -187,8 +193,11 @@ See the example below for how to configure **dotmd.nvim**.
       "DotMdPick",
       "DotMdOpen",
      },
+     event = "VeryLazy",
      ---@type DotMd.Config
-     opts = {},
+     opts = {
+      picker = "snacks" -- or "fzf" or "telescope" based on your preference
+     },
      keys = {
       {
        "<leader>nc",
@@ -411,8 +420,8 @@ When you create a new journal file, **dotmd.nvim**
 
 PICKER ~
 
-1. Uses `vim.ui.select` for file list or grep.
-2. If `snacks.nvim` is installed, uses `snacks.picker.grep()` or `snacks.picker.files()` for enhanced UX.
+1. Uses `vim.ui.select` for file list or grep as fallback or default.
+2. You can choose to use `snacks.nvim`, `fzf-lua`, or `telescope.nvim` for the picker based on your preference.
 3. Can filter by file type (notes, todo, journal, or all).
 
 
@@ -539,14 +548,16 @@ PICK ~
 Pick or search files in **dotmd.nvim** directories by `type`.
 
 
-  [!note] Recommended to use `snacks.nvim` for enhanced UX, else will fallback to
-  `vim.ui.select`.
+  [!note] Recommended to any of the pickers `snacks.nvim`, `fzf-lua`, or
+  `telescope.nvim` for enhanced UX, else will fallback to `vim.ui.select`.
 
   [!warning] `grep` option is not supported and will do nothing for the fallback.
 >lua
     ---@alias DotMd.PickType "notes" | "todos" | "journal" | "all" Pick type
+    ---@alias DotMd.PickerType "telescope" | "fzf" | "snacks" Picker type
     
     ---@class DotMd.PickOpts
+    ---@field picker? DotMd.PickerType Picker type, default is based on `picker` in config
     ---@field type? DotMd.PickType Pick type, default is `notes`
     ---@field grep? boolean Grep the selected type directory for a string, default is false
     
@@ -556,9 +567,6 @@ Pick or search files in **dotmd.nvim** directories by `type`.
 
 You can also use the command `:DotMdPick` to pick or search files in
 **dotmd.nvim** directories by `type`. And it supports the same options.
-
-Since I am exclusively using `snacks.nvim`, if you need some other picker to be
-integrated, feel free to help out and send in a PR for it.
 
 
 NAVIGATE TO PREVIOUS/NEXT NEAREST JOURNAL OR TODO FILE ~

--- a/lua/dotmd/config.lua
+++ b/lua/dotmd/config.lua
@@ -7,6 +7,7 @@ local defaults = {
 	root_dir = "~/dotmd",
 	default_split = "none",
 	rollover_todo = true,
+	picker = nil,
 	dir_names = {
 		notes = "notes",
 		todo = "todo",

--- a/lua/dotmd/health.lua
+++ b/lua/dotmd/health.lua
@@ -39,14 +39,41 @@ function M.check()
 		)
 	end
 
+	if vim.fn.executable("grep") == 1 then
+		report_status("ok", "'grep' command found.")
+	else
+		report_status("error", "'grep' command not found. Please install grep.")
+	end
+
 	separator("dotmd - Optional Dependencies")
-	-- Check for optional dependency: snacks.nvim
+
 	if pcall(require, "snacks") then
 		report_status("ok", "snacks.nvim is installed (optional dependency).")
 	else
 		report_status(
 			"warn",
 			"snacks.nvim not found. It's optional, but recommended for enhanced fuzzy finding."
+		)
+	end
+
+	if pcall(require, "fzf-lua") then
+		report_status("ok", "fzf-lua is installed (optional dependency).")
+	else
+		report_status(
+			"warn",
+			"fzf-lua not found. It's optional, but recommended for enhanced fuzzy finding."
+		)
+	end
+
+	if pcall(require, "telescope") then
+		report_status(
+			"ok",
+			"telescope.nvim is installed (optional dependency)."
+		)
+	else
+		report_status(
+			"warn",
+			"telescope.nvim not found. It's optional, but recommended for enhanced fuzzy finding."
 		)
 	end
 
@@ -69,24 +96,6 @@ function M.check()
 				.. root_dir
 				.. ". It will be created on demand."
 		)
-	end
-
-	separator("dotmd - Module Load Checks")
-	-- List required dotmd modules to check if they load successfully.
-	local required_modules = {
-		"dotmd.commands",
-		"dotmd.config",
-		"dotmd.directories",
-		"dotmd.todos",
-		"dotmd.utils",
-	}
-	for _, mod in ipairs(required_modules) do
-		local mod_ok, _ = pcall(require, mod)
-		if mod_ok then
-			report_status("ok", "Module '" .. mod .. "' loaded successfully.")
-		else
-			report_status("error", "Module '" .. mod .. "' failed to load.")
-		end
 	end
 end
 

--- a/lua/dotmd/picker.lua
+++ b/lua/dotmd/picker.lua
@@ -1,0 +1,111 @@
+local M = {}
+
+---@param opts DotMd.PickOpts Options for picking the file
+---@param dirs string[] The directories to pick from
+---@param prompt string The prompt to show
+---@return boolean status true if successful, false if not
+function M.snacks(opts, dirs, prompt)
+	local snacks_ok, snacks = pcall(require, "snacks")
+
+	if not (snacks_ok and snacks and snacks.picker) then
+		vim.notify(
+			"Snacks.nvim not found, fallback to native vim.ui.select",
+			vim.log.levels.WARN
+		)
+		return false
+	end
+
+	if opts.grep then
+		snacks.picker.grep({ dirs = dirs, prompt = prompt })
+	else
+		snacks.picker.files({ dirs = dirs, prompt = prompt })
+	end
+	return true
+end
+
+---@param opts DotMd.PickOpts Options for picking the file
+---@param dirs string[] The directories to pick from
+---@param prompt string The prompt to show
+---@return boolean status true if successful, false if not
+function M.telescope(opts, dirs, prompt)
+	local telescope_ok, telescope = pcall(require, "telescope.builtin")
+
+	if not (telescope_ok and telescope) then
+		vim.notify(
+			"Telescope not found, fallback to native vim.ui.select",
+			vim.log.levels.WARN
+		)
+		return false
+	end
+
+	if opts.grep then
+		telescope.live_grep({
+			prompt_title = prompt,
+			search_dirs = dirs,
+		})
+	else
+		-- Telescope's find_files works best with a single cwd.
+		if #dirs == 1 then
+			telescope.find_files({
+				prompt_title = prompt,
+				cwd = dirs[1],
+			})
+		else
+			telescope.find_files({
+				prompt_title = prompt,
+				-- Fallback: use the current working directory if multiple dirs exist.
+				cwd = vim.fn.getcwd(),
+			})
+		end
+	end
+	return true
+end
+
+---@param opts DotMd.PickOpts Options for picking the file
+---@param dirs string[] The directories to pick from
+---@param prompt string The prompt to show
+---@return boolean status true if successful, false if not
+function M.fzf(opts, dirs, prompt)
+	local fzf_ok, fzf_lua = pcall(require, "fzf-lua")
+
+	if not (fzf_ok and fzf_lua) then
+		vim.notify(
+			"FZF not found, fallback to native vim.ui.select",
+			vim.log.levels.WARN
+		)
+		return false
+	end
+
+	if opts.grep then
+		-- For grep, if there's only one directory then use 'cwd'
+		if #dirs == 1 then
+			fzf_lua.live_grep({
+				prompt = prompt,
+				cwd = dirs[1],
+			})
+		else
+			-- If multiple directories, pass them with 'search_dirs'
+			fzf_lua.live_grep({
+				prompt = prompt,
+				search_dirs = dirs,
+			})
+		end
+	else
+		-- For files, the documentation recommends using the 'cwd' option.
+		-- If there's only one directory, use it; otherwise, fallback to the current working directory.
+		local cwd = #dirs == 1 and dirs[1] or vim.fn.getcwd()
+		fzf_lua.files({
+			prompt = prompt,
+			cwd = cwd,
+			actions = {
+				["default"] = function(selected)
+					vim.cmd("edit " .. vim.fn.fnameescape(selected.path))
+				end,
+			},
+		})
+	end
+
+	return true
+end
+
+return M

--- a/lua/dotmd/prompt.lua
+++ b/lua/dotmd/prompt.lua
@@ -32,8 +32,48 @@ function M.input_note_name(base_path, opts)
 
 		utils.write_file(note_path, display_name, config.templates.notes)
 
-		utils.open_file(note_path, opts)
+		utils.open_file(note_path, opts.split)
 	end)
+end
+
+---@param dirs string[] The directories to pick from
+---@param prompt_name_type string The type of the prompt
+---@param prompt string The prompt to show
+---@return boolean status true if successful, false if not
+function M.native_select_files(dirs, prompt_name_type, prompt)
+	local directories = require("dotmd.directories")
+
+	local function fuzzy_filter(query, items)
+		query = query:lower()
+		return vim.tbl_filter(function(item)
+			return item.display:lower():find(query, 1, true) ~= nil
+		end, items)
+	end
+
+	local items = directories.prepare_items_for_select(dirs)
+	if #items == 0 then
+		vim.notify(
+			"No " .. prompt_name_type .. " files found in specified directories",
+			vim.log.levels.WARN
+		)
+		return false
+	end
+
+	vim.ui.select(items, {
+		prompt = prompt,
+		format_item = function(item)
+			return item.display
+		end,
+		kind = "note",
+		fuzzy = true,
+		filter = fuzzy_filter,
+	}, function(selected)
+		if selected then
+			vim.cmd("edit " .. vim.fn.fnameescape(selected.value))
+		end
+	end)
+
+	return true
 end
 
 return M

--- a/lua/dotmd/types.lua
+++ b/lua/dotmd/types.lua
@@ -1,10 +1,12 @@
 ---@alias DotMd.Config.DirNameKeys "notes" | "todo" | "journal"
 ---@alias DotMd.Split "vertical" | "horizontal" | "none" Split direction
 ---@alias DotMd.PickType "notes" | "todos" | "journal" | "all" Pick type
+---@alias DotMd.PickerType "telescope" | "fzf" | "snacks" Picker type
 
 ---@class DotMd.Config
 ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
 ---@field default_split? DotMd.Split Split direction for new or existing files, default is `none`
+---@field picker? DotMd.PickerType Picker type, default is `nil`
 ---@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
 ---@field dir_names? DotMd.Config.DirNames
 ---@field templates? Dotmd.Config.Templates
@@ -24,6 +26,7 @@
 ---@field split? DotMd.Split Split direction for new or existing files, default is based on `default_split` in config
 
 ---@class DotMd.PickOpts
+---@field picker? DotMd.PickerType Picker type, default is based on `picker` in config
 ---@field type? DotMd.PickType Pick type, default is `notes`
 ---@field grep? boolean Grep the selected type directory for a string, default is false
 


### PR DESCRIPTION
With this change, user can now setup their desired `picker` in the
config, and when call the picker function, it will pick up the
configured picker from config.

User can also on demand select other picker in the `pick` function if
they want to.

Regardless what picker are configured, if the picker is not found or not
configured, it will fallback to the basic `vim.ui.select` picker.
