### PR TITLE
feat(config): disable `rollover` by default and add configurable `rollover.heading`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,13 @@ require("dotmd").setup({
 ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
 ---@field default_split? DotMd.Split Split direction for new or existing files, default is `none`
 ---@field picker? DotMd.PickerType Picker type, default is `nil`
----@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
+---@field rollover_todo? DotMd.Config.RolloverTodo
 ---@field dir_names? DotMd.Config.DirNames
 ---@field templates? Dotmd.Config.Templates
+
+---@class DotMd.Config.RolloverTodo
+---@field enabled? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
+---@field heading? string Heading to search for in your todos template, default is "Tasks"
 
 ---@class DotMd.Config.DirNames
 ---@field notes? string Directory name for notes, default is "notes"
@@ -125,7 +129,10 @@ require("dotmd").setup({
 {
  root_dir = "~/dotmd",
  default_split = "none",
- rollover_todo = true,
+ rollover_todo = {
+  enabled = false,
+  heading = "Tasks",
+ },
  picker = nil,
  dir_names = {
   notes = "notes",
@@ -214,8 +221,11 @@ See the example below for how to configure **dotmd.nvim**.
  ---@type DotMd.Config
  opts = {
   root_dir = "~/dotmd" -- set it to your desired directory or remain at it is
-  picker = "snacks" -- or "fzf" or "telescope" or "mini" based on your preference
   default_split = "none" -- or "vertical" or "horizontal" based on your preference
+  rollover_todo = {
+   enabled = true, -- enable rollover
+  },
+  picker = "snacks" -- or "fzf" or "telescope" or "mini" based on your preference
  },
  keys = {
   {

--- a/doc/dotmd.nvim.txt
+++ b/doc/dotmd.nvim.txt
@@ -104,9 +104,13 @@ DEFAULT OPTIONS ~
     ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
     ---@field default_split? DotMd.Split Split direction for new or existing files, default is `none`
     ---@field picker? DotMd.PickerType Picker type, default is `nil`
-    ---@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
+    ---@field rollover_todo? DotMd.Config.RolloverTodo
     ---@field dir_names? DotMd.Config.DirNames
     ---@field templates? Dotmd.Config.Templates
+    
+    ---@class DotMd.Config.RolloverTodo
+    ---@field enabled? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
+    ---@field heading? string Heading to search for in your todos template, default is "Tasks"
     
     ---@class DotMd.Config.DirNames
     ---@field notes? string Directory name for notes, default is "notes"
@@ -121,7 +125,10 @@ DEFAULT OPTIONS ~
     {
      root_dir = "~/dotmd",
      default_split = "none",
-     rollover_todo = true,
+     rollover_todo = {
+      enabled = false,
+      heading = "Tasks",
+     },
      picker = nil,
      dir_names = {
       notes = "notes",
@@ -211,8 +218,11 @@ See the example below for how to configure **dotmd.nvim**.
      ---@type DotMd.Config
      opts = {
       root_dir = "~/dotmd" -- set it to your desired directory or remain at it is
-      picker = "snacks" -- or "fzf" or "telescope" or "mini" based on your preference
       default_split = "none" -- or "vertical" or "horizontal" based on your preference
+      rollover_todo = {
+       enabled = true, -- enable rollover
+      },
+      picker = "snacks" -- or "fzf" or "telescope" or "mini" based on your preference
      },
      keys = {
       {

--- a/lua/dotmd/commands.lua
+++ b/lua/dotmd/commands.lua
@@ -84,7 +84,7 @@ function M.create_todo_today(opts)
 				config.templates.todos
 			)
 
-			if config.rollover_todo == true then
+			if config.rollover_todo.enabled == true then
 				local unchecked_tasks, source_path =
 					todos.rollover_previous_todo_to_today(todo_dir, today)
 				if unchecked_tasks and source_path then

--- a/lua/dotmd/config.lua
+++ b/lua/dotmd/config.lua
@@ -6,7 +6,10 @@ M.config = {}
 local defaults = {
 	root_dir = "~/dotmd",
 	default_split = "none",
-	rollover_todo = true,
+	rollover_todo = {
+		enabled = false,
+		heading = "Tasks",
+	},
 	picker = nil,
 	dir_names = {
 		notes = "notes",

--- a/lua/dotmd/todos.lua
+++ b/lua/dotmd/todos.lua
@@ -5,6 +5,7 @@ local M = {}
 ---@param today string|osdate
 ---@return string[]|nil, string|nil
 function M.rollover_previous_todo_to_today(todo_dir, today)
+	local config = require("dotmd.config").config
 	local previous_todo_file =
 		require("dotmd.directories").get_nearest_previous_from_date(
 			todo_dir,
@@ -21,7 +22,7 @@ function M.rollover_previous_todo_to_today(todo_dir, today)
 	-- Find the tasks section
 	local in_tasks = false
 	for _, line in ipairs(lines) do
-		if line:match("^##%s+Tasks") then
+		if line:match("^##%s+" .. config.rollover_todo.heading) then
 			in_tasks = true
 			table.insert(new_lines, line)
 		elseif in_tasks and line:match("^##") then

--- a/lua/dotmd/types.lua
+++ b/lua/dotmd/types.lua
@@ -7,9 +7,13 @@
 ---@field root_dir? string Root directory of dotmd, default is `~/dotmd`
 ---@field default_split? DotMd.Split Split direction for new or existing files, default is `none`
 ---@field picker? DotMd.PickerType Picker type, default is `nil`
----@field rollover_todo? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
+---@field rollover_todo? DotMd.Config.RolloverTodo
 ---@field dir_names? DotMd.Config.DirNames
 ---@field templates? Dotmd.Config.Templates
+
+---@class DotMd.Config.RolloverTodo
+---@field enabled? boolean Rollover the nearest previous unchecked todos to today's date, default is `true`
+---@field heading? string Heading to search for in your todos template, default is "Tasks"
 
 ---@class DotMd.Config.DirNames
 ---@field notes? string Directory name for notes, default is "notes"


### PR DESCRIPTION
User now need to explicitly enable rollover and optionally configure the
heading detection to match their template if needed.
