### PR TITLE
fix(commands.create_todo_today): support rollover for multiple headings with configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ require("dotmd").setup({
 
 ---@class DotMd.Config.RolloverTodo
 ---@field enabled? boolean Rollover the nearest previous unchecked todos to today's date, default is `false`
----@field heading? string Heading to search for in your todos template to rollover, default is "Tasks"
+---@field headings? string[] H2 Headings to search for in your todos template to rollover, default is { "Tasks" }
 
 ---@class DotMd.Config.DirNames
 ---@field notes? string Directory name for notes, default is "notes"
@@ -131,7 +131,7 @@ require("dotmd").setup({
  default_split = "none",
  rollover_todo = {
   enabled = false,
-  heading = "Tasks",
+  heading = { "Tasks" },
  },
  picker = nil,
  dir_names = {
@@ -445,6 +445,14 @@ When you create a new todo file, **dotmd.nvim**:
 3. If confirm, rolls over unfinished `- [ ] tasks from the previous file` from the nearest previous todo file (if any and enabled).
 4. Applies the todo template.
 5. Opens the file for editing.
+
+> [!note]
+>
+> - You can configure the headings to search for in your todos template to rollover by setting `rollover_todo.headings` in the config.
+> - Note that only `h2` or `##` is supported for now.
+> - Make sure it actually matches the headings in your template.
+> - If a heading does not exist in previous todo, it will get ignored.
+> - For today's todo file, if a heading doesn't exist in the template, it will append the section at the end of the file (if there's any rollover).
 
 ### Inbox
 

--- a/doc/dotmd.nvim.txt
+++ b/doc/dotmd.nvim.txt
@@ -110,7 +110,7 @@ DEFAULT OPTIONS ~
     
     ---@class DotMd.Config.RolloverTodo
     ---@field enabled? boolean Rollover the nearest previous unchecked todos to today's date, default is `false`
-    ---@field heading? string Heading to search for in your todos template to rollover, default is "Tasks"
+    ---@field headings? string[] H2 Headings to search for in your todos template to rollover, default is { "Tasks" }
     
     ---@class DotMd.Config.DirNames
     ---@field notes? string Directory name for notes, default is "notes"
@@ -127,7 +127,7 @@ DEFAULT OPTIONS ~
      default_split = "none",
      rollover_todo = {
       enabled = false,
-      heading = "Tasks",
+      heading = { "Tasks" },
      },
      picker = nil,
      dir_names = {
@@ -450,6 +450,13 @@ When you create a new todo file, **dotmd.nvim**
 4. Applies the todo template.
 5. Opens the file for editing.
 
+
+  [!note]
+  - You can configure the headings to search for in your todos template to rollover by setting `rollover_todo.headings` in the config.
+  - Note that only `h2` or `##` is supported for now.
+  - Make sure it actually matches the headings in your template.
+  - If a heading does not exist in previous todo, it will get ignored.
+  - For today’s todo file, if a heading doesn’t exist in the template, it will append the section at the end of the file (if there’s any rollover).
 
 INBOX ~
 

--- a/lua/dotmd/commands.lua
+++ b/lua/dotmd/commands.lua
@@ -84,23 +84,27 @@ function M.create_todo_today(opts)
 				config.templates.todos
 			)
 
-			if config.rollover_todo.enabled == true then
-				local unchecked_tasks, source_path =
-					todos.rollover_previous_todo_to_today(todo_dir, today)
-				if unchecked_tasks and source_path then
-					local today_lines = vim.fn.readfile(todo_path)
-					if #today_lines > 0 and today_lines[#today_lines] ~= "" then
-						table.insert(today_lines, "")
-					end
-					vim.list_extend(today_lines, unchecked_tasks)
-					utils.safe_writefile(today_lines, todo_path)
-					vim.notify(
-						string.format(
-							"Rolled over %d unchecked todo(s) from %s",
-							#unchecked_tasks,
-							vim.fn.fnamemodify(source_path, ":t")
+			if
+				config.rollover_todo.enabled == true
+				and config.rollover_todo.headings ~= nil
+				and #config.rollover_todo.headings > 0
+			then
+				for _, heading in ipairs(config.rollover_todo.headings) do
+					local unchecked_tasks, source_path =
+						todos.rollover_previous_todo_to_today(
+							todo_dir,
+							today,
+							heading
 						)
-					)
+
+					if unchecked_tasks and source_path then
+						todos.apply_rollover_todo(
+							todo_path,
+							unchecked_tasks,
+							source_path,
+							heading
+						)
+					end
 				end
 			end
 

--- a/lua/dotmd/config.lua
+++ b/lua/dotmd/config.lua
@@ -8,7 +8,7 @@ local defaults = {
 	default_split = "none",
 	rollover_todo = {
 		enabled = false,
-		heading = "Tasks",
+		headings = { "Tasks" },
 	},
 	picker = nil,
 	dir_names = {

--- a/lua/dotmd/todos.lua
+++ b/lua/dotmd/todos.lua
@@ -3,9 +3,9 @@ local M = {}
 --- Rollover nearest previous todo to today
 ---@param todo_dir string
 ---@param today string|osdate
+---@param header_text string
 ---@return string[]|nil, string|nil
-function M.rollover_previous_todo_to_today(todo_dir, today)
-	local config = require("dotmd.config").config
+function M.rollover_previous_todo_to_today(todo_dir, today, header_text)
 	local previous_todo_file =
 		require("dotmd.directories").get_nearest_previous_from_date(
 			todo_dir,
@@ -19,10 +19,9 @@ function M.rollover_previous_todo_to_today(todo_dir, today)
 	local unchecked_tasks = {}
 	local new_lines = {}
 
-	-- Find the tasks section
 	local in_tasks = false
 	for _, line in ipairs(lines) do
-		if line:match("^##%s+" .. config.rollover_todo.heading) then
+		if line:match("^##%s+" .. header_text) then
 			in_tasks = true
 			table.insert(new_lines, line)
 		elseif in_tasks and line:match("^##") then
@@ -39,12 +38,89 @@ function M.rollover_previous_todo_to_today(todo_dir, today)
 		end
 	end
 
-	if #unchecked_tasks > 0 then
-		require("dotmd.utils").safe_writefile(new_lines, previous_todo_file)
-		return unchecked_tasks, previous_todo_file
+	if #unchecked_tasks == 0 then
+		return nil, nil
 	end
 
-	return nil, nil
+	require("dotmd.utils").safe_writefile(new_lines, previous_todo_file)
+	return unchecked_tasks, previous_todo_file
+end
+
+--- Apply rollover todo to unchecked tasks
+---@param todo_path string
+---@param unchecked_tasks string[]
+---@param source_path string
+---@param header_text string
+---@return nil
+function M.apply_rollover_todo(
+	todo_path,
+	unchecked_tasks,
+	source_path,
+	header_text
+)
+	local utils = require("dotmd.utils")
+
+	local today_lines = vim.fn.filereadable(todo_path) == 1
+			and vim.fn.readfile(todo_path)
+		or {}
+
+	local inserted = false
+	local result_lines = {}
+	local header_found = false
+
+	for i = 1, #today_lines do
+		local line = today_lines[i]
+		table.insert(result_lines, line)
+
+		if not inserted and line:match("^##%s+" .. header_text) then
+			header_found = true
+
+			-- Check if the next line exists and is blank; if not, insert a blank line.
+			if (i + 1 > #today_lines) or (today_lines[i + 1] ~= "") then
+				table.insert(result_lines, "")
+			end
+
+			local insert_pos = i + 1
+
+			while
+				insert_pos <= #today_lines
+				and not today_lines[insert_pos]:match("^##")
+			do
+				table.insert(result_lines, today_lines[insert_pos])
+				insert_pos = insert_pos + 1
+			end
+
+			for _, task in ipairs(unchecked_tasks) do
+				table.insert(result_lines, task)
+			end
+
+			inserted = true
+
+			i = insert_pos - 1 -- Skip already inserted lines
+		end
+	end
+
+	if not header_found then
+		if #result_lines > 0 and result_lines[#result_lines] ~= "" then
+			table.insert(result_lines, "")
+		end
+		table.insert(result_lines, "## " .. header_text)
+		table.insert(result_lines, "")
+		for _, task in ipairs(unchecked_tasks) do
+			table.insert(result_lines, task)
+		end
+	end
+
+	utils.safe_writefile(result_lines, todo_path)
+
+	vim.notify(
+		string.format(
+			"Rolled over %d unchecked todo(s) under '%s' from %s",
+			#unchecked_tasks,
+			header_text,
+			vim.fn.fnamemodify(source_path, ":t")
+		)
+	)
 end
 
 return M

--- a/lua/dotmd/types.lua
+++ b/lua/dotmd/types.lua
@@ -13,7 +13,7 @@
 
 ---@class DotMd.Config.RolloverTodo
 ---@field enabled? boolean Rollover the nearest previous unchecked todos to today's date, default is `false`
----@field heading? string Heading to search for in your todos template to rollover, default is "Tasks"
+---@field headings? string[] H2 Headings to search for in your todos template to rollover, default is { "Tasks" }
 
 ---@class DotMd.Config.DirNames
 ---@field notes? string Directory name for notes, default is "notes"


### PR DESCRIPTION
This change enables user to configure not just one heading but multiple
headings that to be rolled over if any. Note that it only supports `h2`
for now.

Rolled over todos will follow the previous todo's headings and group
them properly.

If the previous has some heading specified but doesn't exist in the
target, it will get appended at the bottom of the target with rollover
details if any.

If the config has some headers configured that doesn't exist in the
previous, it will get ignored.
